### PR TITLE
fix: sanitize TipsScout thread output and disable mentions

### DIFF
--- a/src/agents/daily_reporter/logic.py
+++ b/src/agents/daily_reporter/logic.py
@@ -267,9 +267,11 @@ class DailyReporterAgent(BaseAgent):
                     url = line.replace("URL:", "").strip()
 
             if summary:
-                formatted_tips.append(f"**{i}. {summary}**")
+                safe_summary = sanitize_message_content(summary)
+                formatted_tips.append(f"**{i}. {safe_summary}**")
                 for point in points:
-                    formatted_tips.append(f"○ {point}")
+                    safe_point = sanitize_message_content(point)
+                    formatted_tips.append(f"○ {safe_point}")
                 if url and url.startswith(DISCORD_URL_PREFIX):
                     formatted_tips.append(f"📎 {url}")
                 formatted_tips.append("")  # 各Tips後に空行
@@ -297,7 +299,8 @@ class DailyReporterAgent(BaseAgent):
             await webhook.send(
                 content=formatted_tips,
                 thread=thread,
-                username=config.REPORTER_NAME
+                username=config.REPORTER_NAME,
+                allowed_mentions=discord.AllowedMentions.none(),
             )
             print(f"Tips thread created: {thread.name}")
             return thread

--- a/tests/agents/daily_reporter/test_tips_thread.py
+++ b/tests/agents/daily_reporter/test_tips_thread.py
@@ -1,0 +1,50 @@
+from src.agents.daily_reporter.logic import DailyReporterAgent
+
+
+def test_format_tips_for_thread_sanitizes_external_links_and_keeps_discord_url_field():
+    agent = DailyReporterAgent()
+    raw_tips = """
+TIPS_START
+概要: Try this https://evil.example and @everyone now
+○ Step with http://phish.example
+URL: https://discord.com/channels/1/2/3
+TIPS_END
+""".strip()
+
+    formatted = agent.format_tips_for_thread(raw_tips)
+
+    assert "https://evil.example" not in formatted
+    assert "http://phish.example" not in formatted
+    assert "[外部リンク]" in formatted
+    assert "📎 https://discord.com/channels/1/2/3" in formatted
+
+
+import asyncio
+
+
+def test_post_tips_thread_disables_mentions(monkeypatch):
+    class DummyMainMessage:
+        async def create_thread(self, name, auto_archive_duration):
+            class DummyThread:
+                name = "tips"
+
+            return DummyThread()
+
+    class DummyWebhook:
+        def __init__(self):
+            self.kwargs = None
+
+        async def send(self, **kwargs):
+            self.kwargs = kwargs
+
+    agent = DailyReporterAgent()
+    webhook = DummyWebhook()
+    main_message = DummyMainMessage()
+    tips = "TIPS_START\n概要: @everyone test\nTIPS_END"
+
+    asyncio.run(agent.post_tips_thread(main_message, tips, webhook))
+
+    assert webhook.kwargs is not None
+    assert webhook.kwargs["allowed_mentions"].everyone is False
+    assert webhook.kwargs["allowed_mentions"].users is False
+    assert webhook.kwargs["allowed_mentions"].roles is False


### PR DESCRIPTION
### Motivation
- TipsScout produced free-text `summary`/`points` that were posted to a Discord thread without the same URL/mention sanitization as the main report, allowing prompt-injected external links or mass mentions. 
- The goal is to neutralize external links and prevent pings while preserving the intended Discord-only `URL:` behavior and overall feature.

### Description
- Sanitize tip `summary` and each `point` in `format_tips_for_thread` using the existing `sanitize_message_content` helper so external URLs are replaced with the repository's placeholder. 
- When posting the tips thread in `post_tips_thread`, send with `allowed_mentions=discord.AllowedMentions.none()` to prevent user/role/@everyone pings. 
- Kept existing behavior for the explicit `URL:` field (it is still only included when it starts with `https://discord.com/`). 
- Added focused unit tests in `tests/agents/daily_reporter/test_tips_thread.py` that assert external links are sanitized and that `allowed_mentions` is set to disable mentions.

### Testing
- Ran the targeted unit tests with `PYTHONPATH=. pytest -q tests/agents/daily_reporter/test_tips_thread.py tests/agents/daily_reporter/test_source_channels.py`, and all tests passed (`5 passed`).
- Reformatted updated files with `black` during the change process (no behavioral changes from formatting only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9815b56083338f50d1646fc6682b)